### PR TITLE
feat: CLI tool to output to SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,42 @@ leaving your browser.
 - **Hide the SQL panel** (⬚ in the toolbar) for a full-width diagram.
 - **Light + dark themes**, and it remembers your last schema locally.
 
+## CLI — headless SVG export
+
+Generate an SVG from a SQL file without a browser, useful for CI/CD pipelines:
+
+```bash
+# Install dependencies first (if not already done)
+npm install
+
+# From a file
+node bin/cli.js schema.sql > schema.svg
+
+# Write to a file directly
+node bin/cli.js schema.sql -o schema.svg
+
+# From stdin
+cat schema.sql | node bin/cli.js -o schema.svg
+
+# Options
+node bin/cli.js --help
+```
+
+| Option | Values | Default |
+| ----------------------- | ------------------------------------------------------ | ------------- |
+| `--format <fmt>`        | `auto` `sql` `bigquery` `prisma` `dbml` `mermaid` `plantuml` `sqlalchemy` `sequelize` | `auto` |
+| `--theme <theme>`       | `dark` `light`                                         | `dark`        |
+| `--direction <dir>`     | `LR` `TB`                                              | `LR`          |
+| `--spacing <s>`         | `compact` `comfortable` `spacious`                     | `comfortable` |
+| `-o, --output <file>`   | Path to write the SVG file                             | stdout        |
+
+**GitHub Actions example:**
+
+```yaml
+- name: Generate ERD
+  run: node bin/cli.js docs/schema.sql -o docs/schema.svg
+```
+
 ## Run locally
 
 ```bash

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,6 +2,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 import { parseSchema } from '../src/parse.js';
+import { inferLinks } from '../src/infer-links.js';
 import { layout } from '../src/layout.js';
 import { exportSVG } from '../src/svg-export.js';
 
@@ -12,6 +13,7 @@ Usage: sql-to-er-diagram [options] [input-file]
 
 Options:
   -o, --output <file>  Write SVG to file instead of stdout
+  --tables <t1,t2>     Only include these tables (comma-separated, case-insensitive)
   --format <fmt>       auto|sql|bigquery|prisma|dbml|mermaid|plantuml|sqlalchemy|sequelize  (default: auto)
   --theme <theme>      dark|light  (default: dark)
   --direction <dir>    LR|TB  (default: LR)
@@ -28,6 +30,7 @@ const { values, positionals } = parseArgs({
   args: process.argv.slice(2),
   options: {
     format:    { type: 'string', default: 'auto' },
+    tables:    { type: 'string' },
     theme:     { type: 'string', default: 'dark' },
     direction: { type: 'string', default: 'LR' },
     spacing:   { type: 'string', default: 'comfortable' },
@@ -48,6 +51,16 @@ const sql = inputFile
   : readFileSync(process.stdin.fd, 'utf8');
 
 const model = parseSchema(sql, values.format);
+model.relations.push(...inferLinks(model));
+
+if (values.tables) {
+  const keep = new Set(values.tables.split(',').map(s => s.trim().toLowerCase()));
+  model.tables = model.tables.filter(t => keep.has(t.key));
+  model.relations = model.relations.filter(
+    r => keep.has(r.fromTable.toLowerCase()) && keep.has(r.toTable.toLowerCase())
+  );
+}
+
 layout(model, { dir: values.direction, spacing: values.spacing });
 const svg = exportSVG(model, values.theme);
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+import { parseSchema } from '../src/parse.js';
+import { layout } from '../src/layout.js';
+import { exportSVG } from '../src/svg-export.js';
+
+const HELP = `
+Usage: sql-to-er-diagram [options] [input-file]
+
+  input-file           SQL (or other supported format) file. Reads stdin if omitted.
+
+Options:
+  -o, --output <file>  Write SVG to file instead of stdout
+  --format <fmt>       auto|sql|bigquery|prisma|dbml|mermaid|plantuml|sqlalchemy|sequelize  (default: auto)
+  --theme <theme>      dark|light  (default: dark)
+  --direction <dir>    LR|TB  (default: LR)
+  --spacing <s>        compact|comfortable|spacious  (default: comfortable)
+  -h, --help           Show this help
+
+Examples:
+  sql-to-er-diagram schema.sql > schema.svg
+  sql-to-er-diagram schema.sql -o schema.svg --theme=light
+  cat schema.sql | sql-to-er-diagram -o schema.svg
+`.trim();
+
+const { values, positionals } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    format:    { type: 'string', default: 'auto' },
+    theme:     { type: 'string', default: 'dark' },
+    direction: { type: 'string', default: 'LR' },
+    spacing:   { type: 'string', default: 'comfortable' },
+    output:    { type: 'string', short: 'o' },
+    help:      { type: 'boolean', short: 'h', default: false },
+  },
+  allowPositionals: true,
+});
+
+if (values.help) {
+  process.stdout.write(HELP + '\n');
+  process.exit(0);
+}
+
+const inputFile = positionals[0];
+const sql = inputFile
+  ? readFileSync(inputFile, 'utf8')
+  : readFileSync(process.stdin.fd, 'utf8');
+
+const model = parseSchema(sql, values.format);
+layout(model, { dir: values.direction, spacing: values.spacing });
+const svg = exportSVG(model, values.theme);
+
+if (!svg) {
+  process.stderr.write('No tables found in input.\n');
+  process.exit(1);
+}
+
+if (values.output) {
+  writeFileSync(values.output, svg, 'utf8');
+} else {
+  process.stdout.write(svg);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "dbdiga",
+  "name": "sql-to-er-diagram",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dbdiga",
+      "name": "sql-to-er-diagram",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.4"
       },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "license": "MIT",
   "type": "module",
   "description": "Turn a SQL schema script into a clean, interactive ER diagram. Fast, free, runs in your browser.",
+  "bin": {
+    "sql-to-er-diagram": "./bin/cli.js"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/src/diagram.js
+++ b/src/diagram.js
@@ -1164,14 +1164,15 @@ export class Diagram {
           const owners = pkByCol.get(cl).filter(k => k !== t.key);
           if (owners.length === 1) { tk = owners[0]; tc = c.name; }
         }
-        // 2) <foo>_id / <foo>id -> table foo / foos, on its PK
+        // 2) <foo>_id / <foo>id / <foo>_uuid -> table foo / foos, on matching column or PK
         if (!tk) {
-          const m = cl.match(/^(.+?)_?id$/);
+          const m = cl.match(/^(.+?)_?(id|uuid)$/);
           if (m && m[1]) {
             const cand = tableByName.get(m[1]) || tableByName.get(m[1] + 's') || tableByName.get(m[1] + 'es');
             if (cand && cand !== t.key) {
-              const pk = (tables.find(x => x.key === cand)?.columns || []).find(x => x.pk);
-              if (pk) { tk = cand; tc = pk.name; }
+              const cols = (tables.find(x => x.key === cand)?.columns || []);
+              const col = cols.find(x => x.name.toLowerCase() === m[2]) || cols.find(x => x.pk);
+              if (col) { tk = cand; tc = col.name; }
             }
           }
         }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -60,6 +60,18 @@ function measureCtx() {
 }
 
 export function measureTable(t) {
+  if (typeof document === 'undefined') {
+    // Node.js fallback: approximate with per-font character widths.
+    // Monospace columns are highly predictable; sans-serif header is a reasonable average.
+    const nameW = t.name.length * 8.5 + PAD_X * 2 + 24;
+    let w = nameW;
+    for (const c of t.columns) {
+      const total = BADGE_W + c.name.length * 7.8 + GAP + (c.type || '').length * 7.2 + PAD_X * 2;
+      if (total > w) w = total;
+    }
+    w = Math.max(MIN_W, Math.min(MAX_W, Math.ceil(w)));
+    return { w, h: HEADER_H + t.columns.length * ROW_H, rowH: ROW_H, headerH: HEADER_H };
+  }
   const ctx = measureCtx();
   ctx.font = HEADER_FONT;
   let w = ctx.measureText(t.name).width + PAD_X * 2 + 24;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an installable command-line tool to generate SVG ER diagrams from SQL (supports stdin, input files, and `-o/--output`), with configurable `--format`, `--theme`, `--direction`, and `--spacing`.
  * Enabled headless SVG export for non-browser use.
* **Bug Fixes**
  * Improved automatic table relationship inference for additional foreign-key column name patterns (including `*_uuid`/`*uuid`).
  * Added Node.js-friendly diagram sizing fallback when browser measurements aren’t available.
* **Documentation**
  * Expanded the README with full CLI usage examples and a workflow snippet to generate `docs/schema.svg`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->