### PR TITLE
fix: embedded diagrams are stretched

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.local
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ leaving your browser.
   gzip-compressed + base64. The `#…` fragment is never sent to a server, so sharing
   needs **no backend**, and opening the link restores the exact diagram.
 - **Export** to **PNG** (raster) and **SVG** (vector).
+- **Embed**: copies an `<iframe>` snippet for a read-only, live-panning/zooming
+  version of the diagram — see [Embedding a diagram](#embedding-a-diagram) below.
 
 ### Editor & appearance
 
@@ -98,6 +100,39 @@ npm run preview  # preview the production build locally
 - **Netlify / Vercel / Cloudflare Pages** — build command `npm run build`, publish dir `dist`.
 - **Any web server / S3 bucket** — just upload the contents of `dist/`.
 
+## Embedding a diagram
+
+Click **Embed** to copy an `<iframe>` snippet that renders a read-only, live
+version of the diagram (pan / zoom still work, editing doesn't) — same idea as
+**Share**, just wrapped in a frame instead of a link:
+
+```html
+<iframe src="https://sqltoerdiagram.com/?embed=1#s=…" width="100%"
+        style="border:1px solid #e5e7eb;border-radius:10px;aspect-ratio:1200/700"
+        title="ER diagram"></iframe>
+```
+
+- **Responsive by default, no JavaScript required**: the snippet has no fixed
+  `height` — it uses CSS `aspect-ratio`, baked in from however the diagram was
+  framed (zoom + pan) when you clicked **Embed**. Drop it into a narrow sidebar
+  or a full-width article and it resizes cleanly at any width. This works even
+  though the diagram is served cross-origin — a host page normally can't read
+  an iframe's content size to auto-size it, but `aspect-ratio` sidesteps that
+  entirely: it's plain CSS on the *host's own* iframe element, so no
+  `postMessage` bridge is needed.
+- **You can still set your own `height` / `max-height`**: `aspect-ratio` is just
+  the suggested default so the frame isn't a fixed size — it's plain CSS on
+  your own `<iframe>`, so replace or add to it however you like, e.g.
+  `style="width:100%;max-height:400px"`. You don't need to work out an aspect
+  ratio yourself; if the box you give it ends up a different shape than the
+  one it was composed at, the diagram scales down to fit inside it (like
+  `object-fit: contain`) rather than cropping — it may just leave a little
+  empty margin on one axis instead of filling the box edge-to-edge.
+- Requires a browser with `aspect-ratio` support (every evergreen browser,
+  Safari 15+) to size itself with no configured height. Older browsers, or a
+  host page that sets its own fixed height, fall back to the iframe's
+  specified/default size — the diagram still fits itself inside that box.
+
 ## Supported SQL
 
 - `CREATE [OR REPLACE] [TEMPORARY | TRANSIENT] TABLE [IF NOT EXISTS] name ( ... )` with quoted / backtick / `[bracket]` / `schema.qualified` names.
@@ -124,11 +159,11 @@ Select **BigQuery** from the dialect dropdown to work with BigQuery SQL instead 
 
 ## Shortcuts
 
-| Key | Action |
-| --- | --- |
-| **⌘ / Ctrl + Enter** | Re-arrange |
-| **Double-click** canvas | Zoom in |
-| Drag the pane divider | Resize the editor |
+| Key                     | Action             |
+| ----------------------- | ------------------ |
+| **⌘ / Ctrl + Enter**   | Re-arrange         |
+| **Double-click** canvas | Zoom in            |
+| Drag the pane divider   | Resize the editor  |
 
 ## License
 

--- a/src/diagram.js
+++ b/src/diagram.js
@@ -32,6 +32,7 @@ export class Diagram {
     this.pinnedKeys = null;        // Set of focused table + neighbour keys
     this.onZoom = null;
     this.onLayoutChange = null;    // fired after a drag / pan / zoom so positions persist
+    this.referenceViewport = null; // {w,h,cam} snapshot for embeds — see freezeViewport()
     this.onEdit = null;            // callback({kind, tableKey, colName?, value})
     this.onAddColumn = null;       // callback(tableKey)
     this.editing = null;           // active inline editor
@@ -126,11 +127,62 @@ export class Diagram {
     this.viewH = rect.height;
     this.canvas.width = Math.round(rect.width * this.dpr);
     this.canvas.height = Math.round(rect.height * this.dpr);
+    this._fitReference();
     this.markDirty();
   }
 
+  // an embed's box can change absolute size — the host page's own layout, or
+  // a `max-height`/fixed `height` the host set that doesn't match the aspect
+  // ratio we suggested — so rescale the camera to contain the same composed
+  // crop rather than cropping or over-zooming it. Uses the smaller of the two
+  // axis factors (like object-fit: contain), so a box that's proportionally
+  // shorter/narrower than the reference just gets a little empty margin on
+  // the other axis instead of clipping content.
+  _fitReference() {
+    const ref = this.referenceViewport;
+    if (!ref || !ref.w || !ref.h) return;
+    const factor = Math.min(this.viewW / ref.w, this.viewH / ref.h);
+    const centerX = (ref.w / 2 - ref.cam.x) / ref.cam.scale;
+    const centerY = (ref.h / 2 - ref.cam.y) / ref.cam.scale;
+    this.cam.scale = ref.cam.scale * factor;
+    this.cam.x = this.viewW / 2 - centerX * this.cam.scale;
+    this.cam.y = this.viewH / 2 - centerY * this.cam.scale;
+  }
+
+  // snapshot the current camera + viewport as the reference frame for
+  // proportional rescaling on future resizes. Embeds call this once the
+  // camera is set (from the share link or a fit()) so a later box resize
+  // scales the view to contain the same composition instead of cropping it.
+  // The normal editor never calls this, so its resize() keeps panning/zoom
+  // untouched across window resizes, as before.
+  freezeViewport() {
+    this.referenceViewport = { w: this.viewW, h: this.viewH, cam: { ...this.cam } };
+  }
+
+  // restore a camera as composed at a refW x refH viewport (from a share
+  // payload) and immediately contain-fit it to the CURRENT box size, so an
+  // embed's very first paint already shows the full composition instead of
+  // cropping to whatever box it happens to load into — the normal
+  // setCamera() has no reference viewport to correct against, so it just
+  // reapplies the numbers verbatim (right for opening a share link in the
+  // full app, where the window is a reasonable stand-in for "big enough").
+  setReferenceCamera(cam, refW, refH) {
+    if (!cam) return;
+    this.cam = { x: cam.x, y: cam.y, scale: cam.scale };
+    this.referenceViewport = { w: refW, h: refH, cam: { ...this.cam } };
+    this._fitReference();
+    this.markDirty();
+    this.onZoom?.(this.cam.scale);
+  }
+
   start() {
-    this.resize();
+    // ResizeObserver fires once immediately on observe() (covering the initial
+    // size) and again on every subsequent box-size change for any reason —
+    // window resizes, but also late reflows (font swaps, scrollbar appearing,
+    // an embedding page's layout still settling). A single getBoundingClientRect()
+    // read here plus a window-level 'resize' listener isn't enough: an iframe
+    // embed can have its box change size without the window itself resizing.
+    new ResizeObserver(() => this.resize()).observe(this.canvas);
     requestAnimationFrame(this._loop);
   }
 

--- a/src/diagram.js
+++ b/src/diagram.js
@@ -1164,14 +1164,15 @@ export class Diagram {
           const owners = pkByCol.get(cl).filter(k => k !== t.key);
           if (owners.length === 1) { tk = owners[0]; tc = c.name; }
         }
-        // 2) <foo>_id / <foo>id -> table foo / foos, on its PK
+        // 2) <foo>_id / <foo>id / <foo>_uuid -> table foo / foos, on matching column or PK
         if (!tk) {
-          const m = cl.match(/^(.+?)_?id$/);
+          const m = cl.match(/^(.+?)_?(id|uuid)$/);
           if (m && m[1]) {
             const cand = tableByName.get(m[1]) || tableByName.get(m[1] + 's') || tableByName.get(m[1] + 'es');
             if (cand && cand !== t.key) {
-              const pk = (tables.find(x => x.key === cand)?.columns || []).find(x => x.pk);
-              if (pk) { tk = cand; tc = pk.name; }
+              const cols = (tables.find(x => x.key === cand)?.columns || []);
+              const col = cols.find(x => x.name.toLowerCase() === m[2]) || cols.find(x => x.pk);
+              if (col) { tk = cand; tc = col.name; }
             }
           }
         }

--- a/src/main.js
+++ b/src/main.js
@@ -55,7 +55,13 @@ function collectLayout() {
   }
   return {
     positions,
-    camera: { x: Math.round(diagram.cam.x), y: Math.round(diagram.cam.y), scale: +diagram.cam.scale.toFixed(4) },
+    // refW/refH: the canvas size this camera was composed at — lets an embed
+    // contain-fit the exact same crop into whatever box it loads into later,
+    // instead of reapplying x/y/scale verbatim against an unrelated box size.
+    camera: {
+      x: Math.round(diagram.cam.x), y: Math.round(diagram.cam.y), scale: +diagram.cam.scale.toFixed(4),
+      refW: Math.round(diagram.viewW), refH: Math.round(diagram.viewH),
+    },
     annotations: diagram.annotations.map(a => ({ ...a })),
     hidden: [...diagram.hidden],
     manualLinks: diagram.manualLinks.map(l => ({ from: { ...l.from }, to: { ...l.to } })),
@@ -277,6 +283,7 @@ function rebuild({ arrange = false, restore = null } = {}) {
   diagram.setModel(result);
   diagram._tmapDirty = true;
 
+  let referenceSet = false;    // true once setReferenceCamera() has anchored diagram.referenceViewport
   if (arrange) {
     layout(result, layoutOpts, diagram.hidden);
     diagram.fit();
@@ -285,8 +292,14 @@ function rebuild({ arrange = false, restore = null } = {}) {
     diagram.setManualLinks(restore.manualLinks);     // restore user-drawn / inferred links
     placeNewTables(result);                          // tables not in the saved layout
     diagram.setAnnotations(sanitizeAnnotations(restore.annotations));
-    if (restore.camera) diagram.setCamera(restore.camera);
-    else diagram.fit();
+    if (restore.camera) {
+      const c = restore.camera;
+      // embeds contain-fit the camera to whatever box they actually load
+      // into (see setReferenceCamera); opening a share link in the full app
+      // just reapplies the numbers as before — no unrelated box size to fit
+      if (isEmbed && c.refW && c.refH) { diagram.setReferenceCamera(c, c.refW, c.refH); referenceSet = true; }
+      else diagram.setCamera(c);
+    } else diagram.fit();
   } else if (firstRender) {
     layout(result, layoutOpts, diagram.hidden);
     diagram.fit();
@@ -299,6 +312,12 @@ function rebuild({ arrange = false, restore = null } = {}) {
   firstRender = false;
   saveLayoutDebounced();
   renderTables();
+  // embeds pin the camera to the frame it was composed at (see resize()'s
+  // contain-fit rescale) so a later box resize scales the same crop instead
+  // of cropping it further. setReferenceCamera() already anchored this to
+  // the author's original frame (see above) — don't clobber that reference
+  // with the current (legacy-link fallback / arrange / firstRender) camera.
+  if (isEmbed && !referenceSet) diagram.freezeViewport();
 }
 
 function updateStatus(result, sql) {
@@ -657,9 +676,17 @@ $('btn-embed').addEventListener('click', async () => {
   try { payload = await encodeShare(project); }
   catch (err) { console.error(err); return; }
   const src = location.origin + location.pathname + '?embed=1#s=' + payload;
+  // bake in the aspect ratio of the canvas as it's framed right now, so a
+  // fluid-width embed keeps this exact composition at any size — no JS or
+  // cross-origin messaging needed, `aspect-ratio` is plain CSS on the host's
+  // own iframe element. `height` must stay unset (not even a fallback value):
+  // aspect-ratio only computes a dimension that's auto, so a definite height
+  // attribute would win and the box would never adopt the aspect ratio.
+  const w = Math.round(diagram.viewW) || 16, h = Math.round(diagram.viewH) || 9;
   const snippet =
-    `<iframe src="${src}" width="100%" height="500" loading="lazy"\n` +
-    `        style="border:1px solid #e5e7eb;border-radius:10px" title="ER diagram"></iframe>`;
+    `<iframe src="${src}" width="100%" loading="lazy"\n` +
+    `        style="border:1px solid #e5e7eb;border-radius:10px;aspect-ratio:${w}/${h}"\n` +
+    `        title="ER diagram"></iframe>`;
   showCodeModal('Embed this diagram', snippet, null, 'embed');
 });
 
@@ -707,8 +734,6 @@ window.addEventListener('mousemove', (e) => {
 window.addEventListener('mouseup', () => {
   if (dragSplit) { dragSplit = null; document.body.style.cursor = ''; }
 });
-
-window.addEventListener('resize', () => diagram.resize());
 
 // keyboard shortcuts
 window.addEventListener('keydown', (e) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedded diagrams now preserve their intended framing as the host iframe resizes.
  * Generated embed snippets use responsive sizing with CSS aspect ratios.
  * Improved automatic relationship detection for additional foreign-key naming patterns.

* **Documentation**
  * Expanded embedding guidance with iframe examples, sizing instructions, and browser fallback details.
  * Improved formatting in the shortcuts reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->